### PR TITLE
VL-11_Add-auto-position-for-datepicers-calendar_Dmytro-Holdobin

### DIFF
--- a/src/composable.adjustElementPosition/index.js
+++ b/src/composable.adjustElementPosition/index.js
@@ -1,0 +1,98 @@
+import { ref, computed, toValue } from "vue";
+
+export const POSITION = {
+  left: "left",
+  right: "right",
+  top: "top",
+  bottom: "bottom",
+  auto: "auto",
+};
+
+export function useAdjustElementPosition(
+  anchorElement,
+  targetElement,
+  position,
+  preferredPosition,
+) {
+  const preferredOpenDirectionY = ref(preferredPosition?.y || POSITION.bottom);
+  const preferredOpenDirectionX = ref(preferredPosition?.x || POSITION.left);
+
+  const localAnchorElement = computed(() => toValue(anchorElement));
+  const localTargetElement = computed(() => toValue(targetElement));
+  const localPosition = computed(() => toValue(position));
+  const localPreferredPosition = computed(() => toValue(preferredPosition));
+
+  const isTop = computed(() => {
+    if (localPosition.value.y !== POSITION.auto) {
+      return localPosition.value.y === POSITION.top;
+    }
+
+    return preferredOpenDirectionY.value === POSITION.top;
+  });
+
+  const isLeft = computed(() => {
+    if (localPosition.value.x !== POSITION.auto) {
+      return localPosition.value.x === POSITION.left;
+    }
+
+    return preferredOpenDirectionX.value === POSITION.right;
+  });
+
+  const isBottom = computed(() => {
+    if (localPosition.value.y !== POSITION.auto) {
+      return localPosition.value.y === POSITION.bottom;
+    }
+
+    return preferredOpenDirectionY.value === POSITION.bottom;
+  });
+
+  const isRight = computed(() => {
+    if (localPosition.value.x !== POSITION.auto) {
+      return localPosition.value.y === POSITION.right;
+    }
+
+    return preferredOpenDirectionX.value === POSITION.right;
+  });
+
+  function adjustPositionY() {
+    if (typeof window === "undefined") return;
+
+    const spaceAbove = localAnchorElement.value.getBoundingClientRect().top;
+    const spaceBelow = window.innerHeight - localAnchorElement.value.getBoundingClientRect().bottom;
+    const hasEnoughSpaceBelow =
+      spaceBelow > localTargetElement.value.getBoundingClientRect().height;
+    const hasEnoughSpaceAbove =
+      spaceAbove > localTargetElement.value.getBoundingClientRect().height;
+
+    if (localPreferredPosition.value.y === POSITION.top) {
+      preferredOpenDirectionY.value =
+        hasEnoughSpaceBelow || spaceBelow > spaceAbove ? POSITION.bottom : POSITION.top;
+    }
+
+    if (localPreferredPosition.value.y === POSITION.bottom) {
+      preferredOpenDirectionY.value =
+        hasEnoughSpaceAbove || spaceAbove > spaceBelow ? POSITION.top : POSITION.bottom;
+    }
+  }
+
+  function adjustPositionX() {
+    if (typeof window === "undefined") return;
+
+    const spaceRight = localAnchorElement.value.getBoundingClientRect().right;
+    const spaceLeft = window.innerWidth - localAnchorElement.value.getBoundingClientRect().left;
+    const hasEnoughSpaceLeft = spaceLeft > localTargetElement.value.getBoundingClientRect().width;
+    const hasEnoughSpaceRight = spaceRight > localTargetElement.value.getBoundingClientRect().width;
+
+    if (localPreferredPosition.value.x === POSITION.left) {
+      preferredOpenDirectionX.value =
+        hasEnoughSpaceRight || spaceRight > spaceLeft ? POSITION.right : POSITION.left;
+    }
+
+    if (localPreferredPosition.value.x === POSITION.right) {
+      preferredOpenDirectionX.value =
+        hasEnoughSpaceLeft || spaceLeft > spaceRight ? POSITION.left : POSITION.right;
+    }
+  }
+
+  return { isTop, isRight, isBottom, isLeft, adjustPositionY, adjustPositionX };
+}

--- a/src/ui.form-date-picker-range/composables/attrs.composable.js
+++ b/src/ui.form-date-picker-range/composables/attrs.composable.js
@@ -4,10 +4,14 @@ import { cx, cva } from "../../service.ui";
 import { computed, watchEffect } from "vue";
 
 import defaultConfig from "../configs/default.config";
+import { POSITION } from "../../composable.adjustElementPosition";
 
-export default function useAttrs(props, { isShownMenu }) {
+export default function useAttrs(props, { isShownMenu, isTop, isRight }) {
   const { config, getAttrs } = useUI(defaultConfig, () => props.config);
   const { menu } = config.value;
+
+  const openDirectionY = computed(() => (isTop.value ? POSITION.top : POSITION.bottom));
+  const openDirectionX = computed(() => (isRight.value ? POSITION.right : POSITION.left));
 
   const cvaMenu = cva({
     base: menu.base,
@@ -15,7 +19,9 @@ export default function useAttrs(props, { isShownMenu }) {
     compoundVariants: menu.compoundVariants,
   });
 
-  const menuClasses = computed(() => cvaMenu({ openDirection: props.openDirection }));
+  const menuClasses = computed(() =>
+    cvaMenu({ openDirectionY: openDirectionY.value, openDirectionX: openDirectionX.value }),
+  );
 
   const wrapperAttrs = getAttrs("wrapper");
   const buttonWrapperAttrsRaw = getAttrs("buttonWrapper");

--- a/src/ui.form-date-picker-range/configs/default.config.js
+++ b/src/ui.form-date-picker-range/configs/default.config.js
@@ -20,11 +20,14 @@ export default /*tw*/ {
     disabled:cursor-not-allowed last:rounded-l-none last:rounded-r-lg first:rounded-l-lg first:rounded-r-none
   `,
   menu: {
-    base: "absolute z-40 mt-2 w-80 overflow-hidden rounded-lg border border-brand-300 bg-white p-2 shadow focus:outline-none",
+    base: "absolute z-40 my-2 w-80 overflow-hidden rounded-lg border border-brand-300 bg-white p-2 shadow focus:outline-none",
     variants: {
-      openDirection: {
+      openDirectionX: {
         left: "left-0",
         right: "right-0",
+      },
+      openDirectionY: {
+        top: "bottom-full mt-0",
       },
     },
   },
@@ -193,7 +196,8 @@ export default /*tw*/ {
   defaultVariants: {
     size: "md",
     variant: "button",
-    openDirection: "left",
+    openDirectionX: "auto",
+    openDirectionY: "auto",
     timepicker: false,
     disabled: false,
     dateFormat: "d.m.Y",

--- a/src/ui.form-date-picker-range/index.stories.js
+++ b/src/ui.form-date-picker-range/index.stories.js
@@ -91,11 +91,29 @@ const OpenDirectionTemplate = (args, { argTypes } = {}) => ({
     <URow class="!flex-col">
       <UDatePickerRange
         class="w-full"
-        v-for="(direction, index) in directions"
-        :open-direction="direction"
+        open-direction-y="top"
         v-bind="args"
         v-model="args.value"
-        :key="index"
+      />
+      <UDatePickerRange
+        class="w-full"
+        open-direction-y="bottom"
+        open-direction-x="right"
+        v-bind="args"
+        v-model="args.value"
+      />
+      <UDatePickerRange
+        class="w-full"
+        open-direction-y="bottom"
+        v-bind="args"
+        v-model="args.value"
+      />
+      <UDatePickerRange
+        class="w-full"
+        open-direction-y="bottom"
+        open-direction-x="left"
+        v-bind="args"
+        v-model="args.value"
       />
     </URow>
   `,

--- a/src/ui.form-date-picker/composables/attrs.composable.js
+++ b/src/ui.form-date-picker/composables/attrs.composable.js
@@ -1,12 +1,16 @@
 import useUI from "../../composable.ui";
 import { cva } from "../../service.ui";
-
-import defaultConfig from "../configs/default.config";
 import { computed, watchEffect } from "vue";
 
-export default function useAttrs(props, { isShownCalendar }) {
+import defaultConfig from "../configs/default.config";
+import { POSITION } from "../../composable.adjustElementPosition";
+
+export default function useAttrs(props, { isShownCalendar, isTop, isRight }) {
   const { config, getAttrs } = useUI(defaultConfig, () => props.config);
   const { calendar } = config.value;
+
+  const openDirectionY = computed(() => (isTop.value ? POSITION.top : POSITION.bottom));
+  const openDirectionX = computed(() => (isRight.value ? POSITION.right : POSITION.left));
 
   const cvaCalendarWrapper = cva({
     base: calendar.wrapper.base,
@@ -15,7 +19,10 @@ export default function useAttrs(props, { isShownCalendar }) {
   });
 
   const calendarWrapperClasses = computed(() =>
-    cvaCalendarWrapper({ openDirection: props.openDirection }),
+    cvaCalendarWrapper({
+      openDirectionY: openDirectionY.value,
+      openDirectionX: openDirectionX.value,
+    }),
   );
 
   const calendarAttrs = getAttrs("calendar", {

--- a/src/ui.form-date-picker/configs/default.config.js
+++ b/src/ui.form-date-picker/configs/default.config.js
@@ -8,11 +8,14 @@ export default /*tw*/ {
   },
   calendar: {
     wrapper: {
-      base: "absolute z-40 mt-2",
+      base: "absolute z-40 my-2",
       variants: {
-        openDirection: {
+        openDirectionX: {
           left: "left-0",
           right: "right-0",
+        },
+        openDirectionY: {
+          top: "bottom-full mt-0",
         },
       },
     },
@@ -109,7 +112,8 @@ export default /*tw*/ {
     dateFormat: "Y-m-d",
     userFormat: "F j, Y",
     size: "md",
-    openDirection: "left",
+    openDirectionX: "auto",
+    openDirectionY: "auto",
     timepicker: false,
     disabled: false,
     maxDate: undefined,

--- a/src/ui.form-date-picker/index.stories.js
+++ b/src/ui.form-date-picker/index.stories.js
@@ -76,11 +76,29 @@ const OpenDirectionTemplate = (args, { argTypes } = {}) => ({
     <URow class="!flex-col">
       <UDatePicker
         class="w-full"
-        v-for="(direction, index) in directions"
-        :open-direction="direction"
+        open-direction-y="top"
         v-bind="args"
         v-model="args.value"
-        :key="index"
+      />
+      <UDatePicker
+        class="w-full"
+        open-direction-y="bottom"
+        open-direction-x="right"
+        v-bind="args"
+        v-model="args.value"
+      />
+      <UDatePicker
+        class="w-full"
+        open-direction-y="bottom"
+        v-bind="args"
+        v-model="args.value"
+      />
+      <UDatePicker
+        class="w-full"
+        open-direction-y="bottom"
+        open-direction-x="left"
+        v-bind="args"
+        v-model="args.value"
       />
     </URow>
   `,


### PR DESCRIPTION
- Added adjustElementPosition composable to position element relatively to another element

- Added auto position for datepickers calendar
- Added props for datepickers to set position of calendar
- Updated datepickers stories

https://ilevel.atlassian.net/jira/software/c/projects/VL/boards/11?selectedIssue=VL-11