### PR TITLE
VL_Add-time-format-for-datepicker_Dmytro-Holdobin

### DIFF
--- a/src/ui.form-calendar/configs/default.config.js
+++ b/src/ui.form-calendar/configs/default.config.js
@@ -123,6 +123,7 @@ export default /*tw*/ {
     range: false,
     timepicker: false,
     dateFormat: undefined,
+    dateTimeFormat: undefined,
     maxDate: undefined,
     minDate: undefined,
     /* icons */

--- a/src/ui.form-calendar/configs/default.config.js
+++ b/src/ui.form-calendar/configs/default.config.js
@@ -119,7 +119,8 @@ export default /*tw*/ {
     okLabel: "Ok",
   },
   defaults: {
-    userFormat: "j F, Y",
+    userDateFormat: "j F, Y",
+    userDateTimeFormat: "j F, Y - H:i:S",
     range: false,
     timepicker: false,
     dateFormat: undefined,

--- a/src/ui.form-calendar/index.stories.js
+++ b/src/ui.form-calendar/index.stories.js
@@ -68,4 +68,4 @@ MinMax.args = {
 };
 
 export const DateFormat = DefaultTemplate.bind({});
-DateFormat.args = { dateFormat: "d.m.Y", userFormat: "d.m.Y", value: "28.06.2024" };
+DateFormat.args = { dateFormat: "d.m.Y", userDateFormat: "d.m.Y", value: "28.06.2024" };

--- a/src/ui.form-calendar/index.vue
+++ b/src/ui.form-calendar/index.vue
@@ -242,9 +242,17 @@ const props = defineProps({
   /**
    * User friendly date format.
    */
-  userFormat: {
+  userDateFormat: {
     type: String,
-    default: getDefault(defaultConfig, UCalendar).userFormat,
+    default: getDefault(defaultConfig, UCalendar).userDateFormat,
+  },
+
+  /**
+   * Same as user format, but used when timepicker is enabled.
+   */
+  userDateTimeFormat: {
+    type: String,
+    default: getDefault(defaultConfig, UCalendar).userDateTimeFormat,
   },
 
   /**
@@ -394,6 +402,18 @@ const locale = computed(() => {
   };
 });
 
+const isTimepickerEnabled = computed(() => {
+  return props.timepicker && !props.range;
+});
+
+const actualDateFormat = computed(() => {
+  return isTimepickerEnabled.value ? props.dateTimeFormat : props.dateFormat;
+});
+
+const actualUserFormat = computed(() => {
+  return isTimepickerEnabled.value ? props.userDateTimeFormat : props.userDateFormat;
+});
+
 const userFormatLocale = computed(() => {
   const { months, weekdays } = currentLocale.value;
 
@@ -419,14 +439,6 @@ const userFormatLocale = computed(() => {
       longhand: getSortedLocale(weekdaysLonghand, LOCALE_TYPE.day),
     },
   };
-});
-
-const isTimepickerEnabled = computed(() => {
-  return props.timepicker && !props.range;
-});
-
-const actualDateFormat = computed(() => {
-  return isTimepickerEnabled.value ? props.dateTimeFormat : props.dateFormat;
 });
 
 const isModelRangeType = computed(() => {
@@ -524,9 +536,9 @@ const formattedDate = computed(() => {
 });
 
 const userFormattedDate = computed(() => {
-  const date = formatDate(selectedDate.value, props.userFormat, userFormatLocale.value);
+  const date = formatDate(selectedDate.value, actualUserFormat.value, userFormatLocale.value);
   const dateTo = props.range
-    ? formatDate(selectedDateTo.value, props.userFormat, userFormatLocale.value)
+    ? formatDate(selectedDateTo.value, actualUserFormat.value, userFormatLocale.value)
     : undefined;
 
   return props.range ? `${date} ${SEPARATOR} ${dateTo}` : date;

--- a/src/ui.form-date-picker-range/index.stories.js
+++ b/src/ui.form-date-picker-range/index.stories.js
@@ -150,7 +150,7 @@ MinMax.args = {
 export const DateFormat = DefaultTemplate.bind({});
 DateFormat.args = {
   dateFormat: "d.m.Y",
-  userFormat: "d.m.Y",
+  userDateFormat: "d.m.Y",
   value: { from: "28.06.2024", to: "30.06.2024" },
 };
 

--- a/src/ui.form-date-picker/configs/default.config.js
+++ b/src/ui.form-date-picker/configs/default.config.js
@@ -108,7 +108,8 @@ export default /*tw*/ {
     okLabel: "Ok",
   },
   defaults: {
-    userFormat: "j F, Y",
+    userDateFormat: "j F, Y",
+    userDateTimeFormat: "j F, Y - H:i:S",
     size: "md",
     openDirectionX: "auto",
     openDirectionY: "auto",

--- a/src/ui.form-date-picker/configs/default.config.js
+++ b/src/ui.form-date-picker/configs/default.config.js
@@ -116,6 +116,7 @@ export default /*tw*/ {
     timepicker: false,
     disabled: false,
     dateFormat: undefined,
+    dateTimeFormat: undefined,
     maxDate: undefined,
     minDate: undefined,
   },

--- a/src/ui.form-date-picker/index.stories.js
+++ b/src/ui.form-date-picker/index.stories.js
@@ -133,13 +133,13 @@ export const placeholder = DefaultTemplate.bind({});
 placeholder.args = { placeholder: "some placeholder" };
 
 export const DateFormat = DefaultTemplate.bind({});
-DateFormat.args = { dateFormat: "d.m.Y", userFormat: "d.m.Y", modelValue: "28.06.2024" };
+DateFormat.args = { dateFormat: "d.m.Y", userDateFormat: "d.m.Y", modelValue: "28.06.2024" };
 
 export const Timepicker = DefaultTemplate.bind({});
 Timepicker.args = {
   timepicker: true,
   modelValue: new Date(2024, 2, 14, 12, 24, 14),
-  userFormat: "j F, Y - H:i:S",
+  userDateFormat: "j F, Y - H:i:S",
 };
 
 export const MinMax = DefaultTemplate.bind({});

--- a/src/ui.form-date-picker/index.vue
+++ b/src/ui.form-date-picker/index.vue
@@ -47,6 +47,7 @@
         tabindex="-1"
         :timepicker="timepicker"
         :date-format="dateFormat"
+        :date-time-format="dateTimeFormat"
         :user-format="userFormat"
         :max-date="maxDate"
         :min-date="minDate"
@@ -215,6 +216,14 @@ const props = defineProps({
   dateFormat: {
     type: String,
     default: getDefault(defaultConfig, UDatePicker).dateFormat,
+  },
+
+  /**
+   * Same as date format, but used when timepicker is enabled.
+   */
+  dateTimeFormat: {
+    type: String,
+    default: getDefault(defaultConfig, UCalendar).dateTimeFormat,
   },
 
   /**

--- a/src/ui.form-date-picker/index.vue
+++ b/src/ui.form-date-picker/index.vue
@@ -48,7 +48,8 @@
         :timepicker="timepicker"
         :date-format="dateFormat"
         :date-time-format="dateTimeFormat"
-        :user-format="userFormat"
+        :user-date-format="userFormat"
+        :user-date-time-format="userDateTimeFormat"
         :max-date="maxDate"
         :min-date="minDate"
         v-bind="calendarAttrs"
@@ -229,9 +230,17 @@ const props = defineProps({
   /**
    * User friendly date format.
    */
-  userFormat: {
+  userDateFormat: {
     type: String,
-    default: getDefault(defaultConfig, UDatePicker).userFormat,
+    default: getDefault(defaultConfig, UDatePicker).userDateFormat,
+  },
+
+  /**
+   * Same as user format, but used when timepicker is enabled.
+   */
+  userDateTimeFormat: {
+    type: String,
+    default: getDefault(defaultConfig, UCalendar).userDateTimeFormat,
   },
 
   /**
@@ -350,7 +359,7 @@ function onBlur(event) {
 }
 
 function formatUserDate(data) {
-  if (props.userFormat !== STANDARD_USER_FORMAT) return data;
+  if (props.userFormat !== STANDARD_USER_FORMAT || props.timepicker) return data;
 
   let prefix = "";
   const formattedDate = data.charAt(0).toUpperCase() + data.toLowerCase().slice(1);


### PR DESCRIPTION
Added timeFormat for datepicker and calendar components to be used insted of dateFormat when timepicker is enabled