### PR TITLE
VL-83_Dynamic-title-for-table-cells_Dmytro-Holdobin

### DIFF
--- a/src/composable.mutationObserver/index.js
+++ b/src/composable.mutationObserver/index.js
@@ -1,0 +1,45 @@
+import { onBeforeUnmount, onMounted, toValue, watch } from "vue";
+
+export function useMutationObserver(
+  target,
+  callBack,
+  config = { childList: true, attributes: true, characterData: true },
+) {
+  const observer = new MutationObserver(callBack);
+
+  onMounted(() => {
+    if (!toValue(target)) return;
+
+    if (Array.isArray) {
+      toValue(target).forEach((element) => {
+        observer.observe(element, config);
+      });
+    } else {
+      observer.observe(toValue(target), config);
+    }
+  });
+
+  watch(
+    () => toValue(target),
+    () => {
+      if (Array.isArray) {
+        toValue(target).forEach((element) => {
+          observer.observe(element, config);
+        });
+
+        return;
+      }
+
+      observer.observe(toValue(target), config);
+    },
+    {
+      deep: true,
+    },
+  );
+
+  onBeforeUnmount(() => {
+    observer.disconnect();
+  });
+
+  return { observer };
+}


### PR DESCRIPTION
- Added dynamic title for table cells witch applied when cell is overflown.
- Added mutationObserver composable.

Change content of table item (onClick on with setTimeout) to test it. Unfortunately it doesn't work when you edit content directly in devtools.

> https://ilevel.atlassian.net/browse/VL-83