### PR TITLE
VL_Replace-select-event-with-click-event-in-dropdown-components_Dmytro-Holdobin

### DIFF
--- a/src/ui.dropdown-badge/UDropdownBadge.vue
+++ b/src/ui.dropdown-badge/UDropdownBadge.vue
@@ -52,19 +52,19 @@
     <UDropdownList
       v-if="isShownOptions"
       ref="dropdownListRef"
-      v-model="selectedItem"
       :size="size"
       :options="options"
       :value-key="valueKey"
       :label-key="labelKey"
       v-bind="dropdownListAttrs"
       :data-test="`${dataTest}-list`"
+      @click-option="onClickOption"
     />
   </div>
 </template>
 
 <script setup>
-import { nextTick, ref, watch, useId } from "vue";
+import { nextTick, ref, useId } from "vue";
 
 import UIcon from "../ui.image-icon/UIcon.vue";
 import UBadge from "../ui.text-badge/UBadge.vue";
@@ -201,14 +201,13 @@ const props = defineProps({
 
 const emit = defineEmits([
   /**
-   * Triggers when dropdown option is selected.
+   * Triggers on dropdown option click.
    * @property {string} value
    */
-  "select",
+  "clickOption",
 ]);
 
 const isShownOptions = ref(false);
-const selectedItem = ref("");
 const dropdownListRef = ref(null);
 
 const elementId = props.id || useId();
@@ -220,12 +219,6 @@ const { config, wrapperAttrs, dropdownBadgeAttrs, dropdownListAttrs, dropdownIco
   },
 );
 
-watch(selectedItem, () => {
-  emit("select", selectedItem.value);
-
-  hideOptions();
-});
-
 function onClickBadge() {
   isShownOptions.value = !isShownOptions.value;
 
@@ -236,5 +229,11 @@ function onClickBadge() {
 
 function hideOptions() {
   isShownOptions.value = false;
+}
+
+function onClickOption(option) {
+  emit("clickOption", option);
+
+  hideOptions();
 }
 </script>

--- a/src/ui.dropdown-button/UDropdownButton.vue
+++ b/src/ui.dropdown-button/UDropdownButton.vue
@@ -53,7 +53,6 @@
     <UDropdownList
       v-if="isShownOptions"
       ref="dropdownListRef"
-      v-model="selectedItem"
       :size="size"
       :options="options"
       :value-key="valueKey"
@@ -61,12 +60,13 @@
       v-bind="dropdownListAttrs"
       :data-test="`${dataTest}-list`"
       @click="onClickList"
+      @click-option="onClickOption"
     />
   </div>
 </template>
 
 <script setup>
-import { nextTick, computed, provide, ref, watch, useId } from "vue";
+import { nextTick, computed, provide, ref, useId } from "vue";
 
 import UIcon from "../ui.image-icon/UIcon.vue";
 import UButton from "../ui.button/UButton.vue";
@@ -227,16 +227,15 @@ const props = defineProps({
 
 const emit = defineEmits([
   /**
-   * Triggers when dropdown option is selected.
+   * Triggers on dropdown option click.
    * @property {string} value
    */
-  "select",
+  "clickOption",
 ]);
 
 provide("hideDropdownOptions", hideOptions);
 
 const isShownOptions = ref(false);
-const selectedItem = ref("");
 const dropdownListRef = ref(null);
 
 const elementId = props.id || useId();
@@ -261,9 +260,9 @@ const iconSize = computed(() => {
   return sizes[props.size];
 });
 
-watch(selectedItem, () => {
-  emit("select", selectedItem.value);
-});
+function onClickOption(option) {
+  emit("clickOption", option);
+}
 
 function onClickButton() {
   isShownOptions.value = !isShownOptions.value;

--- a/src/ui.dropdown-link/UDropdownLink.vue
+++ b/src/ui.dropdown-link/UDropdownLink.vue
@@ -56,7 +56,6 @@
     <UDropdownList
       v-if="isShownOptions"
       ref="dropdownListRef"
-      v-model="selectedItem"
       :size="size"
       :options="options"
       :value-key="valueKey"
@@ -64,12 +63,13 @@
       :data-test="`${dataTest}-list`"
       v-bind="dropdownListAttrs"
       @click="onClickList"
+      @click-option="onClickOption"
     />
   </div>
 </template>
 
 <script setup>
-import { nextTick, computed, provide, ref, watch, useId } from "vue";
+import { nextTick, computed, provide, ref, useId } from "vue";
 
 import UIcon from "../ui.image-icon/UIcon.vue";
 import ULink from "../ui.button-link/ULink.vue";
@@ -221,16 +221,15 @@ const props = defineProps({
 
 const emit = defineEmits([
   /**
-   * Triggers when dropdown option is selected.
+   * Triggers on dropdown option click.
    * @property {string} value
    */
-  "select",
+  "clickOption",
 ]);
 
 provide("hideDropdownOptions", hideOptions);
 
 const isShownOptions = ref(false);
-const selectedItem = ref("");
 const dropdownListRef = ref(null);
 
 const elementId = props.id || useId();
@@ -250,10 +249,6 @@ const iconSize = computed(() => {
   return sizes[props.size];
 });
 
-watch(selectedItem, () => {
-  emit("select", selectedItem.value);
-});
-
 function onClickLink() {
   isShownOptions.value = !isShownOptions.value;
 
@@ -268,5 +263,9 @@ function hideOptions() {
 
 function onClickList() {
   hideOptions();
+}
+
+function onClickOption(option) {
+  emit("clickOption", option);
 }
 </script>

--- a/src/ui.dropdown-list/UDropdownList.vue
+++ b/src/ui.dropdown-list/UDropdownList.vue
@@ -23,7 +23,7 @@
           v-if="!(option && (option.groupLabel || option.isSubGroup)) && !option.isHidden"
           v-bind="optionAttrs"
           :class="optionHighlight(index, option)"
-          @click="select(option)"
+          @click="select(option), onClickOption(option)"
           @mouseenter.self="pointerSet(index)"
         >
           <!--
@@ -204,6 +204,10 @@ const emit = defineEmits([
    * Triggers when option is added.
    */
   "addOption",
+  /**
+   * Triggers on click option.
+   */
+  "clickOption",
 ]);
 
 const wrapperRef = ref(null);
@@ -299,8 +303,13 @@ function optionHighlight(index, option) {
 function addPointerElement({ key } = "Enter") {
   if (props.options.length > 0) {
     select(props.options[pointer.value], key);
+    onClickOption(props.options[pointer.value]);
   }
 
   pointerReset();
+}
+
+function onClickOption(option) {
+  emit("clickOption", option);
 }
 </script>


### PR DESCRIPTION
Dropdown components are not selects, they can't have initial value and should not remember last clicked element, so it's strange that those elements have event named `select` and some internal model value which is not required.

- Removed internal model values from dropdown components.
- Added clickOption event to dropdown components and DropdownList component.