### PR TITLE
VL_UTable-bugs-fix_Vitalii-Dudnik

### DIFF
--- a/src/ui.data-table/UTable.vue
+++ b/src/ui.data-table/UTable.vue
@@ -190,7 +190,7 @@
               :columns="columns"
               :config="config"
               :attrs="keysAttrs"
-              v-bind="getRowAttrs(row)"
+              v-bind="getRowAttrs(row.id)"
               :class="cx([getRowAttrs(row.id).class, getRowClasses(row)])"
               @click="onClickRow"
               @toggle-row-visibility="onToggleRowVisibility"
@@ -610,7 +610,7 @@ function shouldDisplayDateSeparator(rowIndex) {
 }
 
 function getRowAttrs(rowId) {
-  return selectedRows.value.includes(rowId) ? bodyRowCheckedAttrs : bodyRowAttrs;
+  return selectedRows.value.includes(rowId) ? bodyRowCheckedAttrs.value : bodyRowAttrs.value;
 }
 
 function getRowClasses(row) {

--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -16,11 +16,7 @@
       :key="index"
       v-bind="getCellAttrs(key, row, index)"
       :class="
-        cx([
-          getCellAttrs(key, row, index).class,
-          columns[index].tdClass,
-          !row[key]?.contentClasses && getCellClasses(row, key),
-        ])
+        cx([getCellAttrs(key, row, index).class, columns[index].tdClass, getCellClasses(row, key)])
       "
     >
       <div
@@ -42,7 +38,7 @@
 
       <div
         v-if="isCellObject(value)"
-        :class="cx([bodyCellPrimaryAttrs.class, !row[key]?.class && getCellClasses(row, key)])"
+        :class="cx([bodyCellPrimaryAttrs.class, getCellContentClasses(row, key)])"
       >
         <slot :name="`cell-${key}`" :value="value" :row="row">
           <div v-bind="bodyCellPrimaryAttrs" ref="cellRef" :data-test="`${dataTest}-${key}-cell`">
@@ -198,7 +194,13 @@ onMounted(() => {
 });
 
 function getCellClasses(row, key) {
-  const cellClasses = row[key]?.contentClasses || row[key]?.class || "";
+  const cellClasses = row[key]?.class || "";
+
+  return typeof cellClasses === "function" ? cellClasses(row[key].value, row) : cellClasses;
+}
+
+function getCellContentClasses(row, key) {
+  const cellClasses = row[key]?.contentClasses || "";
 
   return typeof cellClasses === "function" ? cellClasses(row[key].value, row) : cellClasses;
 }

--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -198,7 +198,7 @@ onMounted(() => {
 });
 
 function getCellClasses(row, key) {
-  const cellClasses = row[key]?.class || "";
+  const cellClasses = row[key]?.contentClasses || row[key]?.class || "";
 
   return typeof cellClasses === "function" ? cellClasses(row[key].value, row) : cellClasses;
 }

--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -16,7 +16,11 @@
       :key="index"
       v-bind="getCellAttrs(key, row, index)"
       :class="
-        cx([getCellAttrs(key, row, index).class, columns[index].tdClass, getCellClasses(row, key)])
+        cx([
+          getCellAttrs(key, row, index).class,
+          columns[index].tdClass,
+          !row[key]?.contentClasses && getCellClasses(row, key),
+        ])
       "
     >
       <div
@@ -36,7 +40,10 @@
         />
       </div>
 
-      <div v-if="isCellObject(value)">
+      <div
+        v-if="isCellObject(value)"
+        :class="cx([bodyCellPrimaryAttrs.class, !row[key]?.class && getCellClasses(row, key)])"
+      >
         <slot :name="`cell-${key}`" :value="value" :row="row">
           <div v-bind="bodyCellPrimaryAttrs" ref="cellRef" :data-test="`${dataTest}-${key}-cell`">
             {{ getCellPrimaryContent(value) }}


### PR DESCRIPTION
- Fix getRowAttrs function (you need to add `.value` for each returned Attrs via v-bind function to apply them correctly to a tr element)

- Add `contentClasses` property check to apply classes either for `td` itself, or on content div instead