### PR TITLE
VL-112_V-tooltip-improvments_Dmtyro-Holdobin

### DIFF
--- a/src/directives/vTooltip.js
+++ b/src/directives/vTooltip.js
@@ -25,11 +25,25 @@ export default {
   mounted(el, bindings) {
     if (isSSR) return;
 
-    tippy(el, merge(settings, bindings.value || {}));
+    if (typeof bindings.value === "string" && bindings.value.length) {
+      tippy(el, merge(settings, { content: bindings.value }));
+
+      return;
+    }
+
+    if (bindings.value.content && bindings.value.content.length) {
+      tippy(el, merge(settings, bindings.value || {}));
+    }
   },
 
   updated(el, bindings) {
     if (!el._tippy || isSSR) return;
+
+    if (typeof bindings.value === "string") {
+      el._tippy.setProps(merge(settings, { content: bindings.value }));
+
+      return;
+    }
 
     el._tippy.setProps(merge(settings, bindings.value || {}));
   },


### PR DESCRIPTION
- Added override for overload which accept only content string.
- Disabled tooltip when content it falsy value.

> https://ilevel.atlassian.net/browse/VL-112