### PR TITLE
VL_Hide-toggle-visiblity-icon-when-nested-row-is-empty_Dmytro-Holdobin

### DIFF
--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -32,7 +32,10 @@
         v-bind="bodyCellNestedAttrs"
       >
         <UIcon
-          v-if="row.row || (row.nestedData && hasSlotContent($slots['nested-content']))"
+          v-if="
+            (row.row && !isNestedRowEmpty) ||
+            (row.nestedData && hasSlotContent($slots['nested-content']))
+          "
           size="xs"
           internal
           interactive
@@ -230,6 +233,18 @@ const toggleIconConfig = computed(() =>
 const shift = computed(() => (props.row.row ? 1.5 : 2));
 
 const isSingleNestedRow = computed(() => !Array.isArray(props.row.row));
+
+const isNestedRowEmpty = computed(() => {
+  if (!props.row.row) return true;
+
+  if (Array.isArray(props.row.row)) {
+    return props.row.row.some(
+      (nestedRow) => !Object.keys(getFilteredRow(nestedRow, props.columns)).length,
+    );
+  }
+
+  return !Object.keys(getFilteredRow(props.row.row, props.columns)).length;
+});
 
 const getToggleIconName = computed(() => (row) => {
   const isHiddenNestedRow = Array.isArray(row.row)

--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -32,10 +32,7 @@
         v-bind="bodyCellNestedAttrs"
       >
         <UIcon
-          v-if="
-            (row.row && !isNestedRowEmpty) ||
-            (row.nestedData && hasSlotContent($slots['nested-content']))
-          "
+          v-if="isShownToggleIcon"
           size="xs"
           internal
           interactive
@@ -150,7 +147,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, ref, useSlots } from "vue";
 import { cx } from "../utils/utilUI.js";
 import useUI from "../composables/useUI.js";
 
@@ -211,6 +208,7 @@ const emit = defineEmits(["toggleRowVisibility", "click", "click-cell"]);
 const selectedRows = defineModel("selectedRows", { type: Array, default: () => [] });
 
 const cellRef = ref([]);
+const slots = useSlots();
 
 useMutationObserver(cellRef, setCellTitle, { childList: true });
 
@@ -244,6 +242,13 @@ const isNestedRowEmpty = computed(() => {
   }
 
   return !Object.keys(getFilteredRow(props.row.row, props.columns)).length;
+});
+
+const isShownToggleIcon = computed(() => {
+  return (
+    (props.row.row && !isNestedRowEmpty.value) ||
+    (props.row.nestedData && hasSlotContent(slots["nested-content"]))
+  );
 });
 
 const getToggleIconName = computed(() => (row) => {


### PR DESCRIPTION
Hidden toggle visiblity icon when nested row is empty