### PR TITLE
VL_UTable-nested-row-value-fix_Vitalii-Dudnik

### DIFF
--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -49,7 +49,7 @@
             :class="cx([bodyCellContentAttrs.class, getCellContentClasses(row, key)])"
             :data-test="`${dataTest}-${key}-cell`"
           >
-            {{ value.value || value || HYPHEN_SYMBOL }}
+            {{ formatCellValue(value) }}
           </div>
         </slot>
       </div>
@@ -62,7 +62,7 @@
             :class="cx([bodyCellContentAttrs.class, getCellContentClasses(row, key)])"
             :data-test="`${dataTest}-${key}-cell`"
           >
-            {{ value.value || value || HYPHEN_SYMBOL }}
+            {{ formatCellValue(value) }}
           </div>
         </slot>
       </template>
@@ -275,6 +275,18 @@ function getCellContentClasses(row, key) {
   const cellClasses = row[key]?.contentClasses || "";
 
   return typeof cellClasses === "function" ? cellClasses(row[key].value, row) : cellClasses;
+}
+
+function isEmptyValue(value) {
+  return value == null || (typeof value === "object" && !Object.keys(value).length);
+}
+
+function formatCellValue(value) {
+  if (isEmptyValue(value)) return HYPHEN_SYMBOL;
+
+  const nestedValue = value && typeof value === "object" && "value" in value ? value.value : value;
+
+  return isEmptyValue(nestedValue) ? HYPHEN_SYMBOL : nestedValue;
 }
 
 function getNestedShift() {

--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -278,12 +278,16 @@ function getCellContentClasses(row, key) {
 }
 
 function isEmptyValue(value) {
-  return value == null || (typeof value === "object" && !Object.keys(value).length);
+  return (
+    value === null ||
+    value === undefined ||
+    value === "" ||
+    (Array.isArray(value) && value.length === 0) ||
+    (typeof value === "object" && !Object.keys(value).length)
+  );
 }
 
 function formatCellValue(value) {
-  if (isEmptyValue(value)) return HYPHEN_SYMBOL;
-
   const nestedValue = value && typeof value === "object" && "value" in value ? value.value : value;
 
   return isEmptyValue(nestedValue) ? HYPHEN_SYMBOL : nestedValue;


### PR DESCRIPTION
Fix cell value bug (if value is an empty object - empty curly braces
 are displayed instead of hyphen symbol)