### PR TITLE
VL-147_Fix-dark-mode-story-book-switch_Dmytro-Holdobin

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -16,9 +16,15 @@ import "./index.css";
 import { createVueless } from "../src/index";
 import { createRouter, createWebHistory } from "vue-router";
 
+let vueless;
+
 /* Setup storybook */
 setup((app) => {
-  const vueless = createVueless();
+  /* Needed to prevent recreation of vueless when storybook theme changes */
+  if (!vueless) {
+    vueless = createVueless();
+  }
+
   const router = createRouter({ history: createWebHistory(), routes: [] });
 
   app.config.idPrefix = getRandomId();

--- a/src/composables/useDarkMode.ts
+++ b/src/composables/useDarkMode.ts
@@ -1,12 +1,17 @@
 import { onMounted, ref, nextTick } from "vue";
-import { DARK_MODE_SELECTOR } from "../constants.js";
+import { COLOR_MODE_KEY, DARK_MODE_SELECTOR } from "../constants.js";
+import { ColorMode } from "../types.js";
 
 export function useDarkMode() {
   const isDarkMode = ref(false);
 
   onMounted(async () => {
     await nextTick(() => {
-      isDarkMode.value = document.documentElement.classList.contains(DARK_MODE_SELECTOR);
+      const isDarkModeClass = document.documentElement.classList.contains(DARK_MODE_SELECTOR);
+      const cashedDarkMode = localStorage.getItem(COLOR_MODE_KEY) as ColorMode | null;
+      const isDarkModeCashed = cashedDarkMode !== null && cashedDarkMode === ColorMode.Dark;
+
+      isDarkMode.value = isDarkModeCashed || isDarkModeClass;
 
       window.addEventListener("darkModeChange", ((event: CustomEvent) => {
         isDarkMode.value = Boolean(event.detail);

--- a/src/composables/useDarkMode.ts
+++ b/src/composables/useDarkMode.ts
@@ -6,10 +6,7 @@ export function useDarkMode() {
 
   onMounted(async () => {
     await nextTick(() => {
-      const isDarkModeClass = document.documentElement.classList.contains(DARK_MODE_SELECTOR);
-      const isDarkModeCache = !!Number(localStorage.getItem(DARK_MODE_SELECTOR));
-
-      isDarkMode.value = isDarkModeCache || isDarkModeClass;
+      isDarkMode.value = document.documentElement.classList.contains(DARK_MODE_SELECTOR);
 
       window.addEventListener("darkModeChange", ((event: CustomEvent) => {
         isDarkMode.value = Boolean(event.detail);

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,7 @@ export const GRAYSCALE_COLOR = "grayscale";
 /* Vueless dark mode */
 export const DARK_MODE_SELECTOR = "vl-dark";
 export const LIGHT_MODE_SELECTOR = "vl-light";
+export const COLOR_MODE_KEY = "vl-color-mode";
 
 /* Vueless defaults */
 export const DEFAULT_BRAND_COLOR = GRAYSCALE_COLOR;

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,6 +39,12 @@ import type { LocaleOptions } from "./adatper.locale/vueless.ts";
 
 export type TemplateRefElement = MaybeRef<HTMLElement | HTMLElement[] | null>;
 
+export enum ColorScheme {
+  Dark = "dark",
+  Light = "light",
+  Auto = "auto",
+}
+
 export interface ExtendedKeyClasses {
   [key: string]: Ref<string>;
 }
@@ -80,9 +86,9 @@ export interface ThemeConfig {
   ringOffsetColorDark?: string;
 
   /**
-   * Default dark mode state.
+   * Default color scheme.
    */
-  darkMode?: boolean;
+  colorScheme?: `${ColorScheme}`;
 }
 
 export interface Config extends ThemeConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -88,7 +88,7 @@ export interface ThemeConfig {
   /**
    * Default color mode.
    */
-  ColorMode?: `${ColorMode}`;
+  colorMode?: `${ColorMode}`;
 }
 
 export interface Config extends ThemeConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,7 @@ import type { LocaleOptions } from "./adatper.locale/vueless.ts";
 
 export type TemplateRefElement = MaybeRef<HTMLElement | HTMLElement[] | null>;
 
-export enum ColorScheme {
+export enum ColorMode {
   Dark = "dark",
   Light = "light",
   Auto = "auto",
@@ -86,9 +86,9 @@ export interface ThemeConfig {
   ringOffsetColorDark?: string;
 
   /**
-   * Default color scheme.
+   * Default color mode.
    */
-  colorScheme?: `${ColorScheme}`;
+  ColorMode?: `${ColorMode}`;
 }
 
 export interface Config extends ThemeConfig {

--- a/vueless.config.ts
+++ b/vueless.config.ts
@@ -7,7 +7,7 @@ export default {
   ringOffsetColorLight: "#ffffff", // white
   ringOffsetColorDark: "#111827", // gray-900
   rounding: 8,
-  darkMode: undefined,
+  darkMode: "auto",
   directive: {
     // directive configs
   },


### PR DESCRIPTION
- Fixed storybook color theme switch.
- Removed logic related to caching color scheme and switching it according to browser's settings. It should be up to the user to decide whether they want to track browser's theme, make theme static, cache it and under which key. 

> https://ilevel.atlassian.net/browse/VL-147