### PR TITLE
VL_Remove-td-slot-wrappers_Dmytro-Holdobin

### DIFF
--- a/src/ui.data-table/UTable.vue
+++ b/src/ui.data-table/UTable.vue
@@ -206,7 +206,6 @@ const {
   tableWrapperAttrs,
   headerRowAttrs,
   bodyRowAfterAttrs,
-  bodyRowAfterCellAttrs,
   bodyRowBeforeAttrs,
   bodyRowBeforeCellAttrs,
   footerAttrs,
@@ -576,17 +575,11 @@ defineExpose({
       <table v-bind="tableAttrs">
         <thead v-bind="headerAttrs" :style="tableRowWidthStyle">
           <tr v-if="hasSlotContent($slots['before-header'])" v-bind="headerRowAttrs">
-            <td
-              v-if="hasSlotContent($slots['before-header'])"
-              :colspan="colsCount"
-              v-bind="headerCellBaseAttrs"
-            >
-              <!--
+            <!--
                 @slot Use it to add something before header row.
                 @binding {number} cols-count
               -->
-              <slot name="before-header" :cols-count="colsCount" />
-            </td>
+            <slot name="before-header" :cols-count="colsCount" />
           </tr>
 
           <tr v-if="hasSlotContent($slots['before-header'])" v-bind="headerRowAttrs"></tr>
@@ -710,10 +703,8 @@ defineExpose({
               v-if="rowIndex === lastRow && hasSlotContent($slots['after-last-row'])"
               v-bind="bodyRowAfterAttrs"
             >
-              <td :colspan="colsCount" v-bind="bodyRowAfterCellAttrs">
-                <!-- @slot Use it to add something after last row. -->
-                <slot name="after-last-row" />
-              </td>
+              <!-- @slot Use it to add something after last row. -->
+              <slot name="after-last-row" :cols-count="colsCount" />
             </tr>
           </template>
         </tbody>

--- a/src/ui.data-table/config.ts
+++ b/src/ui.data-table/config.ts
@@ -47,7 +47,6 @@ export default /*tw*/ {
   bodyRowBefore: "!p-0",
   bodyRowBeforeCell: "py-1",
   bodyRowAfter: "!p-0",
-  bodyRowAfterCell: "py-1",
   bodyRowDateDivider: "",
   bodyCellBase: {
     base: "p-[1.125rem] py-5 truncate align-top",

--- a/src/ui.data-table/useAttrs.ts
+++ b/src/ui.data-table/useAttrs.ts
@@ -78,9 +78,6 @@ export default function useAttrs(
     bodyRowBeforeCell: {
       base: computed(() => [extendingKeysClasses.bodyCellBase.value]),
     },
-    bodyRowAfterCell: {
-      base: computed(() => [extendingKeysClasses.bodyCellBase.value]),
-    },
     footer: {
       extend: computed(() => [isFooterSticky.value && extendingKeysClasses.stickyFooter.value]),
     },


### PR DESCRIPTION
For more flexability removed <td /> wrappers of "before-header" and "after-last-row"  slots.