### PR TITLE
VL_UTable-toggle-nestedData-fix_Vitalii-Dudnik

### DIFF
--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -46,7 +46,9 @@ const toggleIconConfig = computed(() => {
   const nestedRow = props.row?.row;
   let isShown = false;
 
-  if (Array.isArray(nestedRow)) {
+  if (props.row.nestedData) {
+    isShown = Boolean(props.row.nestedData.isShown);
+  } else if (Array.isArray(nestedRow)) {
     isShown = nestedRow.some((row) => row.isShown);
   } else {
     isShown = Boolean(nestedRow?.isShown);

--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -54,8 +54,6 @@ const toggleIconConfig = computed(() => {
     isShown = Boolean(nestedRow?.isShown);
   }
 
-  console.log(isShown);
-
   return isShown
     ? props.attrs.bodyCellNestedCollapseIconAttrs.value
     : props.attrs.bodyCellNestedExpandIconAttrs.value;

--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -76,10 +76,16 @@ const isNestedRowEmpty = computed(() => {
   return !Object.keys(mapRowColumns(props.row.row, props.columns)).length;
 });
 
+const isNestedDataEmpty = computed(() => {
+  if (!props.row.nestedData) return true;
+
+  return !props.row.nestedData.rows || props.row.nestedData.rows.length === 0;
+});
+
 const isShownToggleIcon = computed(() => {
   return (
     (props.row.row && !isNestedRowEmpty.value) ||
-    (props.row.nestedData && hasSlotContent(slots["nested-content"]))
+    (props.row.nestedData && !isNestedDataEmpty.value && hasSlotContent(slots["nested-content"]))
   );
 });
 

--- a/src/ui.data-table/UTableRow.vue
+++ b/src/ui.data-table/UTableRow.vue
@@ -54,6 +54,8 @@ const toggleIconConfig = computed(() => {
     isShown = Boolean(nestedRow?.isShown);
   }
 
+  console.log(isShown);
+
   return isShown
     ? props.attrs.bodyCellNestedCollapseIconAttrs.value
     : props.attrs.bodyCellNestedExpandIconAttrs.value;
@@ -81,7 +83,7 @@ const isNestedRowEmpty = computed(() => {
 const isNestedDataEmpty = computed(() => {
   if (!props.row.nestedData) return true;
 
-  return !props.row.nestedData.rows || props.row.nestedData.rows.length === 0;
+  return !props.row.nestedData.rows || !props.row.nestedData.rows.length;
 });
 
 const isShownToggleIcon = computed(() => {


### PR DESCRIPTION
Add computed property to check if nestedData.rows exists and its length is more than zero, so that toggle icon is only displayed when nested content is present