### PR TITLE
VL_IconLoader-fix_Vitalii-Dudnik

### DIFF
--- a/src/utils/node/loaderIcon.js
+++ b/src/utils/node/loaderIcon.js
@@ -189,7 +189,7 @@ async function findAndCopyIcons(files) {
       const iconName = groupMatch ? groupMatch[3] : null;
 
       try {
-        if (!iconName) return;
+        if (!iconName) continue;
 
         if (iconName?.includes("?") && iconName?.includes(":")) {
           const [trueName, falseName] = getTernaryValues(iconName);


### PR DESCRIPTION
Fix icon loader bug, when after the first element of array does not match - the function exits immediately.
Instead of "return", "continue" is needed for correct icon parsing