### PR TITLE
VL_Fix-UTable-dataTest-warning_Vitalii-Dudnik

### DIFF
--- a/src/ui.data-table/types.ts
+++ b/src/ui.data-table/types.ts
@@ -133,7 +133,7 @@ export interface UTableRowProps {
   emptyCellLabel?: string;
   selectable: boolean;
   nestedLevel: number;
-  dataTest: string;
+  dataTest: string | null;
   attrs: UTableRowAttrs;
   config: Config;
 }


### PR DESCRIPTION
Fix UTable dataTest type warning, when dataTest is null