### PR TITLE
VL-198_USelect-afterToggle-padding-fix_Vitalii-Dudnik

### DIFF
--- a/src/ui.form-select/config.ts
+++ b/src/ui.form-select/config.ts
@@ -84,7 +84,21 @@ export default /*tw*/ {
   leftSlot: "{>toggle} pl-2.5",
   rightSlot: "{>toggle} pr-2.5",
   beforeToggle: "{>toggle} cursor-auto",
-  afterToggle: "{>toggle} mr-2.5 items-start pt-3 cursor-auto",
+  afterToggle: {
+    base: "{>toggle} mr-2.5 items-start cursor-auto",
+    variants: {
+      size: {
+        sm: "pt-0.5",
+        md: "pt-1",
+        lg: "pt-1.5",
+      },
+    },
+    compoundVariants: [
+      { labelAlign: "topInside", size: "sm", class: "pt-2" },
+      { labelAlign: "topInside", size: "md", class: "pt-3" },
+      { labelAlign: "topInside", size: "lg", class: "pt-4" },
+    ],
+  },
   toggle: {
     base: "flex items-center",
     compoundVariants: [


### PR DESCRIPTION
Adjust afterToggle config key padding-top for correct layout at different sizes and label align

https://ilevel.atlassian.net/jira/software/c/projects/VL/boards/11?selectedIssue=VL-198