### PR TITLE
VL_ULabel-argTypes-adjustment_Vitalii-Dudnik

### DIFF
--- a/src/ui.form-label/storybook/stories.ts
+++ b/src/ui.form-label/storybook/stories.ts
@@ -36,7 +36,6 @@ export default {
       options: (argTypes?.align?.table?.type?.summary as string)
         ?.split(" | ")
         ?.filter((option) => option !== "topInside"),
-      control: "select",
     },
   },
   parameters: {

--- a/src/ui.form-label/storybook/stories.ts
+++ b/src/ui.form-label/storybook/stories.ts
@@ -19,6 +19,8 @@ interface ULabelArgs extends Props {
   enum: "align" | "size";
 }
 
+const argTypes = getArgTypes(ULabel.__name);
+
 export default {
   id: "3210",
   title: "Form Inputs & Controls / Label",
@@ -28,7 +30,14 @@ export default {
     description: "We'll never share your email with anyone else.",
   },
   argTypes: {
-    ...getArgTypes(ULabel.__name),
+    ...argTypes,
+    align: {
+      ...argTypes?.align,
+      options: (argTypes?.align?.table?.type?.summary as string)
+        ?.split(" | ")
+        ?.filter((option) => option !== "topInside"),
+      control: "select",
+    },
   },
   parameters: {
     docs: {


### PR DESCRIPTION
Adjust ULabel "align" prop variants, so that "topInside" is not shown in the storybook to prevent incorrect layout (this variant is used specifically for inputs).