### PR TITLE
VL_Fix-radio-inital-modelValue-update-issue_Dmytro-Holdobin

### DIFF
--- a/src/ui.form-radio/URadio.vue
+++ b/src/ui.form-radio/URadio.vue
@@ -27,7 +27,7 @@ const getRadioGroupSelectedItem = inject("getRadioGroupSelectedItem", null);
 
 const props = withDefaults(defineProps<Props>(), {
   ...getDefaults<Props, Config>(defaultConfig, COMPONENT_NAME),
-  modelValue: () => ({}),
+  modelValue: undefined,
   value: () => ({}),
   label: "",
 });
@@ -72,7 +72,13 @@ watchEffect(() => (radioColor.value = toValue(getRadioGroupColor) || props.color
 watchEffect(() => (radioSize.value = toValue(getRadioGroupSize) || props.size));
 watchEffect(() => (radioDisabled.value = toValue(getRadioGroupDisabled) || props.disabled));
 watchEffect(() => {
-  localValue.value = toValue(getRadioGroupSelectedItem) || null;
+  const radioGroupSelectedItem = toValue(getRadioGroupSelectedItem);
+
+  if (radioGroupSelectedItem === null || isEqual(props.modelValue, radioGroupSelectedItem)) {
+    return;
+  }
+
+  localValue.value = radioGroupSelectedItem || null;
   emit("update:modelValue", props.value);
 });
 


### PR DESCRIPTION
- Fixed issue when initial modelValue of radioGroup were not applied to radio element.
- Fixed issue when radio element emitted value on initial render when initial modelValue was set to null, undefined or empty string.