### PR TITLE
VL-241_Fix-datepicker-range-focus-in-chrome_Dmytro-Holdobin

### DIFF
--- a/src/ui.form-calendar/UCalendarDayView.vue
+++ b/src/ui.form-calendar/UCalendarDayView.vue
@@ -168,6 +168,8 @@ function getDayState(day: Date) {
     hoveredDay.value &&
     !props.selectedDateTo &&
     !dateIsOutOfRange(day, props.selectedDate, hoveredDay.value, props.locale, props.dateFormat);
+  const isLastRangePreview =
+    hoveredDay.value && isInRangePreview && isSameDay(day, hoveredDay.value);
 
   const isInRangePreviewAnotherMonth = isInRangePreview && isAnotherMonthDay;
 
@@ -185,6 +187,7 @@ function getDayState(day: Date) {
     isRangeSameDay,
     isInRangePreview,
     isInRangePreviewAnotherMonth,
+    isLastRangePreview,
   };
 }
 
@@ -334,6 +337,21 @@ defineExpose({
           size="md"
           square
           v-bind="anotherMonthLastDayInRangeAttrs"
+          :disabled="dateIsOutOfRange(day, minDate, maxDate, locale, dateFormat)"
+          :label="formatDate(day, 'j', locale)"
+          @mousedown.prevent.capture
+          @click="onClickDay(day)"
+          @mouseover="onMouseoverDay(day)"
+        />
+
+        <UButton
+          v-else-if="getDayState(day).isLastRangePreview"
+          tabindex="-1"
+          variant="ghost"
+          color="primary"
+          size="md"
+          square
+          v-bind="lastDayInRangeAttrs"
           :disabled="dateIsOutOfRange(day, minDate, maxDate, locale, dateFormat)"
           :label="formatDate(day, 'j', locale)"
           @mousedown.prevent.capture

--- a/src/ui.form-date-picker-range/UDatePickerRange.vue
+++ b/src/ui.form-date-picker-range/UDatePickerRange.vue
@@ -305,7 +305,7 @@ function activate() {
     adjustPositionY();
     adjustPositionX();
 
-    menuRef.value?.focus();
+    menuRef.value?.focus({ preventScroll: true });
   });
 }
 


### PR DESCRIPTION
Fixed issue when click outside worked incorrectly because of focus scroll in Chromium browsers. Changed style of last day in date range preview

> https://ilevel.atlassian.net/browse/VL-241