### PR TITLE
VL-256_USelect-add-clear-event_Vitalii-Dudnik

### DIFF
--- a/src/ui.form-select/USelect.vue
+++ b/src/ui.form-select/USelect.vue
@@ -58,10 +58,15 @@ const emit = defineEmits([
   "searchChange",
 
   /**
-   * Triggers when the option is removed.
+   * Triggers when the option from multiple select is removed.
    * @property {string} option
    */
-  "remove",
+  "removeOption",
+
+  /**
+   * Triggers when the select is cleared.
+   */
+  "clear",
 
   /**
    * Triggers when an option is selected.
@@ -331,7 +336,7 @@ function onClickClearItem(event: MouseEvent, option: Option) {
 
   emit("update:modelValue", value);
   emit("change", { value, options: props.options });
-  emit("remove", option);
+  emit("removeOption", option);
 }
 
 function onClickClear() {
@@ -341,7 +346,7 @@ function onClickClear() {
 
   emit("update:modelValue", value);
   emit("change", { value, options: props.options });
-  emit("remove", props.options);
+  emit("clear");
 
   deactivate();
 }


### PR DESCRIPTION
Refactored `USelect` component: renamed `remove` event to `removeOption` for clarity and added `clear` event to handle select clearing.

https://ilevel.atlassian.net/jira/software/c/projects/VL/boards/11?selectedIssue=VL-256