### PR TITLE
VL_User-configs-auto-imports_Vitalii-Dudnik

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -395,6 +395,7 @@ export const RESOLVED_ICONS_VIRTUAL_MODULE_ID = `\0${ICONS_VIRTUAL_MODULE_ID}`;
 export const VUELESS_TAILWIND_SAFELIST = `${VUELESS_CACHE_DIR}/tailwind/safelist.txt`;
 export const VUELESS_CONFIGS_CACHED_DIR = `${VUELESS_CACHE_DIR}/configs`;
 export const VUELESS_MERGED_CONFIGS_CACHED_DIR = `${VUELESS_CACHE_DIR}/mergedConfigs`;
+export const VUELESS_USER_CONFIGS_CACHED_DIR = `${VUELESS_CACHE_DIR}/userConfigs`;
 export const VUELESS_CONFIG_FILE_NAME = "vueless.config";
 
 /* System error codes */

--- a/src/plugin-vite.js
+++ b/src/plugin-vite.js
@@ -26,6 +26,7 @@ import {
   getVueDirs,
   getVuelessConfigDirs,
   cacheMergedConfigs,
+  cacheUserConfigs,
 } from "./utils/node/helper.js";
 import {
   INTERNAL_ENV,
@@ -124,6 +125,8 @@ export const Vueless = function (options = {}) {
         /* merge and cache component configs. */
         await cacheMergedConfigs(vuelessSrcDir);
       }
+
+      await cacheUserConfigs();
 
       await buildWebTypes(vuelessSrcDir);
       await setCustomPropTypes(vuelessSrcDir);


### PR DESCRIPTION
Add user configuration caching and auto-import functionality:

- Introduced `VUELESS_USER_CONFIGS_CACHED_DIR` constant for user configs.
- Implemented `cacheUserConfigs` function to cache user configuration files.
- Added `autoImportUserConfigs` function to generate an index file for user configs.
- Updated `plugin-vite.js` to call `cacheUserConfigs` during the build process.