### PR TITLE
VL_UCalendar-fix-isOutOfRange-check_Vitalii-Dudnik

### DIFF
--- a/src/ui.form-calendar/UCalendar.vue
+++ b/src/ui.form-calendar/UCalendar.vue
@@ -232,13 +232,15 @@ const localValue = computed({
       parsedDate.setSeconds(Number(secondsRef.value?.value));
     }
 
-    const isOutOfRange = dateIsOutOfRange(
-      parsedDate || new Date(),
-      props.minDate,
-      props.maxDate,
-      locale.value,
-      actualDateFormat.value,
-    );
+    const isOutOfRange =
+      parsedDate !== null &&
+      dateIsOutOfRange(
+        parsedDate,
+        props.minDate,
+        props.maxDate,
+        locale.value,
+        actualDateFormat.value,
+      );
 
     if (isOutOfRange) {
       return;


### PR DESCRIPTION
Refactor date range validation in `UCalendar.vue`

Update `isOutOfRange` logic to ensure it only checks when `parsedDate` is not null.