### PR TITLE
VL_ClearSearchOnSelect-new-prop_Vitalii-Dudnik

### DIFF
--- a/src/ui.dropdown-badge/UDropdownBadge.vue
+++ b/src/ui.dropdown-badge/UDropdownBadge.vue
@@ -281,6 +281,7 @@ const { getDataTest, config, wrapperAttrs, dropdownBadgeAttrs, listboxAttrs, tog
       :value-key="valueKey"
       :group-label-key="groupLabelKey"
       :group-value-key="groupValueKey"
+      :clear-search-on-select="clearSearchOnSelect"
       v-bind="listboxAttrs"
       :data-test="getDataTest('list')"
       @click-option="onClickOption"

--- a/src/ui.dropdown-badge/config.ts
+++ b/src/ui.dropdown-badge/config.ts
@@ -48,6 +48,7 @@ export default /*tw*/ {
     searchable: false,
     multiple: false,
     closeOnSelect: true,
+    clearSearchOnSelect: true,
     /* icons */
     toggleIcon: "keyboard_arrow_down",
   },

--- a/src/ui.dropdown-badge/storybook/stories.ts
+++ b/src/ui.dropdown-badge/storybook/stories.ts
@@ -182,6 +182,21 @@ SearchModelValue.parameters = {
 export const NoCloseOnSelect = SelectableTemplate.bind({});
 NoCloseOnSelect.args = { modelValue: "delivered", closeOnSelect: false };
 
+export const NoClearSearchOnSelect = SelectableTemplate.bind({});
+NoClearSearchOnSelect.args = {
+  modelValue: "delivered",
+  searchable: true,
+  clearSearchOnSelect: false,
+  closeOnSelect: false,
+};
+NoClearSearchOnSelect.parameters = {
+  docs: {
+    story: {
+      height: "250px",
+    },
+  },
+};
+
 export const OptionSelection = SelectableTemplate.bind({});
 OptionSelection.args = { modelValue: "pending" };
 

--- a/src/ui.dropdown-badge/tests/UDropdownBadge.test.ts
+++ b/src/ui.dropdown-badge/tests/UDropdownBadge.test.ts
@@ -329,6 +329,38 @@ describe("UDropdownBadge.vue", () => {
       expect(options[0].text()).toBe("Option 1");
     });
 
+    // ClearSearchOnSelect prop
+    it("passes clearSearchOnSelect prop to UListbox component", async () => {
+      const clearSearchOnSelect = false;
+
+      const component = mount(UDropdownBadge, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+          clearSearchOnSelect,
+        },
+      });
+
+      await component.findComponent(UBadge).trigger("click");
+
+      expect(component.findComponent(UListbox).props("clearSearchOnSelect")).toBe(
+        clearSearchOnSelect,
+      );
+    });
+
+    it("defaults clearSearchOnSelect to true", async () => {
+      const component = mount(UDropdownBadge, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+        },
+      });
+
+      await component.findComponent(UBadge).trigger("click");
+
+      expect(component.findComponent(UListbox).props("clearSearchOnSelect")).toBe(true);
+    });
+
     // CloseOnSelect prop
     it("keeps dropdown open when closeOnSelect is false", async () => {
       const component = mount(UDropdownBadge, {

--- a/src/ui.dropdown-badge/types.ts
+++ b/src/ui.dropdown-badge/types.ts
@@ -101,6 +101,11 @@ export interface Props {
   closeOnSelect?: boolean;
 
   /**
+   * Clear search on option select.
+   */
+  clearSearchOnSelect?: boolean;
+
+  /**
    * Allows multiple selection.
    */
   multiple?: boolean;

--- a/src/ui.dropdown-button/UDropdownButton.vue
+++ b/src/ui.dropdown-button/UDropdownButton.vue
@@ -280,6 +280,7 @@ const { getDataTest, config, dropdownButtonAttrs, listboxAttrs, toggleIconAttrs,
       :value-key="valueKey"
       :group-label-key="groupLabelKey"
       :group-value-key="groupValueKey"
+      :clear-search-on-select="clearSearchOnSelect"
       v-bind="listboxAttrs"
       :data-test="getDataTest('list')"
       @click-option="onClickOption"

--- a/src/ui.dropdown-button/config.ts
+++ b/src/ui.dropdown-button/config.ts
@@ -64,6 +64,7 @@ export default /*tw*/ {
     disabled: false,
     multiple: false,
     closeOnSelect: true,
+    clearSearchOnSelect: true,
     /* icons */
     toggleIcon: "keyboard_arrow_down",
   },

--- a/src/ui.dropdown-button/storybook/stories.ts
+++ b/src/ui.dropdown-button/storybook/stories.ts
@@ -192,6 +192,21 @@ NoCloseOnSelect.args = {
   closeOnSelect: false,
 };
 
+export const NoClearSearchOnSelect = SelectableTemplate.bind({});
+NoClearSearchOnSelect.args = {
+  modelValue: "edit",
+  searchable: true,
+  clearSearchOnSelect: false,
+  closeOnSelect: false,
+};
+NoClearSearchOnSelect.parameters = {
+  docs: {
+    story: {
+      height: "250px",
+    },
+  },
+};
+
 export const OptionSelection = SelectableTemplate.bind({});
 OptionSelection.args = {
   label: "Select status",

--- a/src/ui.dropdown-button/tests/UDropdownButton.test.ts
+++ b/src/ui.dropdown-button/tests/UDropdownButton.test.ts
@@ -335,6 +335,38 @@ describe("UDropdownButton.vue", () => {
       expect(options[0].text()).toBe("Option 2");
     });
 
+    // ClearSearchOnSelect prop
+    it("passes clearSearchOnSelect prop to UListbox component", async () => {
+      const clearSearchOnSelect = false;
+
+      const component = mount(UDropdownButton, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+          clearSearchOnSelect,
+        },
+      });
+
+      await component.findComponent(UButton).trigger("click");
+
+      expect(component.findComponent(UListbox).props("clearSearchOnSelect")).toBe(
+        clearSearchOnSelect,
+      );
+    });
+
+    it("defaults clearSearchOnSelect to true", async () => {
+      const component = mount(UDropdownButton, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+        },
+      });
+
+      await component.findComponent(UButton).trigger("click");
+
+      expect(component.findComponent(UListbox).props("clearSearchOnSelect")).toBe(true);
+    });
+
     // VisibleOptions prop
     it("passes visibleOptions prop to UListbox component", async () => {
       const visibleOptions = 5;

--- a/src/ui.dropdown-button/types.ts
+++ b/src/ui.dropdown-button/types.ts
@@ -101,6 +101,11 @@ export interface Props {
   closeOnSelect?: boolean;
 
   /**
+   * Clear search on option select.
+   */
+  clearSearchOnSelect?: boolean;
+
+  /**
    * Allows multiple selection.
    */
   multiple?: boolean;

--- a/src/ui.dropdown-link/UDropdownLink.vue
+++ b/src/ui.dropdown-link/UDropdownLink.vue
@@ -285,6 +285,7 @@ const { config, getDataTest, wrapperAttrs, dropdownLinkAttrs, listboxAttrs, togg
       :value-key="valueKey"
       :group-label-key="groupLabelKey"
       :group-value-key="groupValueKey"
+      :clear-search-on-select="clearSearchOnSelect"
       v-bind="listboxAttrs"
       :data-test="getDataTest('list')"
       @click-option="onClickOption"

--- a/src/ui.dropdown-link/config.ts
+++ b/src/ui.dropdown-link/config.ts
@@ -45,6 +45,7 @@ export default /*tw*/ {
     searchable: false,
     multiple: false,
     closeOnSelect: true,
+    clearSearchOnSelect: true,
     /* icons */
     toggleIcon: "keyboard_arrow_down",
   },

--- a/src/ui.dropdown-link/storybook/stories.ts
+++ b/src/ui.dropdown-link/storybook/stories.ts
@@ -160,6 +160,21 @@ SearchModelValue.parameters = {
 export const NoCloseOnSelect = SelectableTemplate.bind({});
 NoCloseOnSelect.args = { modelValue: "logout", closeOnSelect: false };
 
+export const NoClearSearchOnSelect = SelectableTemplate.bind({});
+NoClearSearchOnSelect.args = {
+  modelValue: "logout",
+  searchable: true,
+  clearSearchOnSelect: false,
+  closeOnSelect: false,
+};
+NoClearSearchOnSelect.parameters = {
+  docs: {
+    story: {
+      height: "250px",
+    },
+  },
+};
+
 export const OptionSelection = SelectableTemplate.bind({});
 OptionSelection.args = { modelValue: "profile" };
 

--- a/src/ui.dropdown-link/tests/UDropdownLink.test.ts
+++ b/src/ui.dropdown-link/tests/UDropdownLink.test.ts
@@ -341,6 +341,38 @@ describe("UDropdownLink.vue", () => {
       expect(options[0].text()).toBe("Option 3");
     });
 
+    // ClearSearchOnSelect prop
+    it("passes clearSearchOnSelect prop to UListbox component", async () => {
+      const clearSearchOnSelect = false;
+
+      const component = mount(UDropdownLink, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+          clearSearchOnSelect,
+        },
+      });
+
+      await component.findComponent(ULink).trigger("click");
+
+      expect(component.findComponent(UListbox).props("clearSearchOnSelect")).toBe(
+        clearSearchOnSelect,
+      );
+    });
+
+    it("defaults clearSearchOnSelect to true", async () => {
+      const component = mount(UDropdownLink, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+        },
+      });
+
+      await component.findComponent(ULink).trigger("click");
+
+      expect(component.findComponent(UListbox).props("clearSearchOnSelect")).toBe(true);
+    });
+
     // CloseOnSelect prop
     it("keeps dropdown open when closeOnSelect is false", async () => {
       const component = mount(UDropdownLink, {

--- a/src/ui.dropdown-link/types.ts
+++ b/src/ui.dropdown-link/types.ts
@@ -96,6 +96,11 @@ export interface Props {
   closeOnSelect?: boolean;
 
   /**
+   * Clear search on option select.
+   */
+  clearSearchOnSelect?: boolean;
+
+  /**
    * Allows multiple selection.
    */
   multiple?: boolean;

--- a/src/ui.form-listbox/UListbox.vue
+++ b/src/ui.form-listbox/UListbox.vue
@@ -104,7 +104,7 @@ const selectedValue = computed({
     return props.modelValue;
   },
   set: (value) => {
-    if (searchModel.value) searchModel.value = "";
+    if (searchModel.value && props.clearSearchOnSelect && !props.multiple) searchModel.value = "";
 
     emit("update:modelValue", value);
   },

--- a/src/ui.form-listbox/config.ts
+++ b/src/ui.form-listbox/config.ts
@@ -108,6 +108,7 @@ export default /*tw*/ {
     disabled: false,
     addOption: false,
     multiple: false,
+    clearSearchOnSelect: true,
     /* icons */
     addOptionIcon: "add",
     selectedIcon: "check",

--- a/src/ui.form-listbox/storybook/stories.ts
+++ b/src/ui.form-listbox/storybook/stories.ts
@@ -96,6 +96,9 @@ Searchable.args = { searchable: true };
 export const SearchModelValue = DefaultTemplate.bind({});
 SearchModelValue.args = { search: "New York", searchable: true };
 
+export const NoClearSearchOnSelect = DefaultTemplate.bind({});
+NoClearSearchOnSelect.args = { searchable: true, clearSearchOnSelect: false };
+
 export const Multiple = DefaultTemplate.bind({});
 Multiple.args = { multiple: true, modelValue: [] };
 

--- a/src/ui.form-listbox/tests/UListbox.test.ts
+++ b/src/ui.form-listbox/tests/UListbox.test.ts
@@ -507,6 +507,104 @@ describe("UListbox.vue", () => {
       expect(component.emitted("searchBlur")).toBeTruthy();
     });
 
+    it("ClearSearchOnSelect – clears search when option is selected and clearSearchOnSelect is true", async () => {
+      const component = mount(UListbox, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+          clearSearchOnSelect: true,
+        },
+      });
+
+      const searchInput = component.getComponent(UInputSearch);
+
+      // Set search value
+      await searchInput.setValue("Option 1");
+      await flushPromises();
+
+      // Select an option
+      const firstOption = component.find('[vl-key="option"]');
+
+      await firstOption.trigger("click");
+
+      // Check that search was cleared
+      expect(searchInput.props("modelValue")).toBe("");
+    });
+
+    it(`ClearSearchOnSelect –
+        does not clear search when option is selected and clearSearchOnSelect is false`, async () => {
+      const component = mount(UListbox, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+          clearSearchOnSelect: false,
+        },
+      });
+
+      const searchInput = component.getComponent(UInputSearch);
+
+      // Set search value
+      await searchInput.setValue("Option 1");
+      await flushPromises();
+
+      // Select an option
+      const firstOption = component.find('[vl-key="option"]');
+
+      await firstOption.trigger("click");
+
+      // Check that search was NOT cleared
+      expect(searchInput.props("modelValue")).toBe("Option 1");
+    });
+
+    it("ClearSearchOnSelect – defaults to true", async () => {
+      const component = mount(UListbox, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+        },
+      });
+
+      const searchInput = component.getComponent(UInputSearch);
+
+      // Set search value
+      await searchInput.setValue("Option 1");
+      await flushPromises();
+
+      // Select an option
+      const firstOption = component.find('[vl-key="option"]');
+
+      await firstOption.trigger("click");
+
+      // Check that search was cleared (default behavior)
+      expect(searchInput.props("modelValue")).toBe("");
+    });
+
+    it(`ClearSearchOnSelect –
+        does not clear search in multiple mode regardless of clearSearchOnSelect value`, async () => {
+      const component = mount(UListbox, {
+        props: {
+          searchable: true,
+          multiple: true,
+          options: defaultOptions,
+          clearSearchOnSelect: true, // Even when true, should not clear in multiple mode
+        },
+      });
+
+      const searchInput = component.getComponent(UInputSearch);
+
+      // Set search value
+      await searchInput.setValue("Option 1");
+      await flushPromises();
+
+      // Select an option
+      const firstOption = component.find('[vl-key="option"]');
+
+      await firstOption.trigger("click");
+
+      // Check that search was NOT cleared in multiple mode
+      expect(searchInput.props("modelValue")).toBe("Option 1");
+    });
+
     it("Keyboard Navigation – moves pointer down with arrow down", async () => {
       const component = mount(UListbox, {
         props: {

--- a/src/ui.form-listbox/types.ts
+++ b/src/ui.form-listbox/types.ts
@@ -40,6 +40,11 @@ export interface Props {
   searchable?: boolean;
 
   /**
+   * Clear search on option select.
+   */
+  clearSearchOnSelect?: boolean;
+
+  /**
    * Allows multiple selection.
    */
   multiple?: boolean;

--- a/src/ui.form-select/USelect.vue
+++ b/src/ui.form-select/USelect.vue
@@ -821,6 +821,7 @@ const {
         :group-label-key="groupLabelKey"
         :group-value-key="groupValueKey"
         :add-option="addOption"
+        :clear-search-on-select="clearSearchOnSelect"
         tabindex="-1"
         v-bind="listboxAttrs as KeyAttrsWithConfig<UListboxConfig>"
         :data-test="getDataTest()"

--- a/src/ui.form-select/config.ts
+++ b/src/ui.form-select/config.ts
@@ -153,6 +153,7 @@ export default /*tw*/ {
     clearable: true,
     addOption: false,
     closeOnSelect: true,
+    clearSearchOnSelect: true,
     /* icons */
     toggleIcon: "keyboard_arrow_down",
     clearIcon: "close_small",

--- a/src/ui.form-select/storybook/stories.ts
+++ b/src/ui.form-select/storybook/stories.ts
@@ -162,6 +162,21 @@ SearchModelValue.parameters = {
 export const NoCloseOnSelect = DefaultTemplate.bind({});
 NoCloseOnSelect.args = { modelValue: 3, closeOnSelect: false };
 
+export const NoClearSearchOnSelect = DefaultTemplate.bind({});
+NoClearSearchOnSelect.args = {
+  modelValue: 3,
+  searchable: true,
+  clearSearchOnSelect: false,
+  closeOnSelect: false,
+};
+NoClearSearchOnSelect.parameters = {
+  docs: {
+    story: {
+      height: "350px",
+    },
+  },
+};
+
 export const Readonly = DefaultTemplate.bind({});
 Readonly.args = { readonly: true, modelValue: "1", clearable: false };
 

--- a/src/ui.form-select/tests/USelect.test.ts
+++ b/src/ui.form-select/tests/USelect.test.ts
@@ -274,6 +274,33 @@ describe("USelect.vue", () => {
       expect(options[0].text()).toBe("Option 2");
     });
 
+    it("ClearSearchOnSelect – passes clearSearchOnSelect prop to UListbox", async () => {
+      const component = mount(USelect, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+          clearSearchOnSelect: false,
+        },
+      });
+
+      await component.get("[role='combobox']").trigger("focus");
+
+      expect(component.getComponent(UListbox).props("clearSearchOnSelect")).toBe(false);
+    });
+
+    it("ClearSearchOnSelect – defaults to true", async () => {
+      const component = mount(USelect, {
+        props: {
+          searchable: true,
+          options: defaultOptions,
+        },
+      });
+
+      await component.get("[role='combobox']").trigger("focus");
+
+      expect(component.getComponent(UListbox).props("clearSearchOnSelect")).toBe(true);
+    });
+
     it("Clearable – renders clear icon when true", async () => {
       const component = mount(USelect, {
         props: {

--- a/src/ui.form-select/types.ts
+++ b/src/ui.form-select/types.ts
@@ -62,6 +62,11 @@ export interface Props {
   closeOnSelect?: boolean;
 
   /**
+   * Clear search on option select.
+   */
+  clearSearchOnSelect?: boolean;
+
+  /**
    * Left icon name.
    */
   leftIcon?: string;


### PR DESCRIPTION
Add new `clearSearchOnSelect` prop to UListbox, which controls whether to clear search input on option select.